### PR TITLE
supressing task result 'changed'

### DIFF
--- a/tasks/nginx/create/http-auth/files.yml
+++ b/tasks/nginx/create/http-auth/files.yml
@@ -12,6 +12,7 @@
     group: '{{ nginx_group }}'
     mode: '0600'
   with_items: nginx_http_auth_files
+  changed_when: false
 
 - name: "nginx:create:http-auth:users | Create users for http authentication"
   htpasswd:


### PR DESCRIPTION
File operation 'touch' always gives result 'changed'. This can be avoided by doing stat operation, but is much harder implement with lists. Fow now i'm suggesting just ignore that.
